### PR TITLE
lmi: overlay: Use a mask for rounded corners

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -21,7 +21,8 @@ SOONG_CONFIG_XIAOMI_KONA_FOD_POS_Y = 1655
 SOONG_CONFIG_XIAOMI_KONA_FOD_SIZE = 202
 
 # Kernel
-TARGET_KERNEL_CONFIG := vendor/lmi_defconfig
+include device/xiaomi/lmi-kernel/BoardConfigKernel.mk
+TARGET_KERNEL_CONFIG := vendor/kona-perf_defconfig
 
 # Properties
 TARGET_PRODUCT_PROP += $(DEVICE_PATH)/product.prop

--- a/device.mk
+++ b/device.mk
@@ -37,5 +37,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     DeviceParts
 
+# Kernel
+$(call inherit-product, device/xiaomi/lmi-kernel/kernel.mk)
+
 # Inherit from vendor blobs
 $(call inherit-product, vendor/xiaomi/lmi/lmi-vendor.mk)

--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -2,5 +2,9 @@
   {
     "repository": "android_device_xiaomi_sm8250-common",
     "target_path": "device/xiaomi/sm8250-common"
+  },
+  {
+    "repository": "android_device_xiaomi_lmi-kernel",
+    "target_path": "device/xiaomi/lmi-kernel"
   }
 ]

--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -20,5 +20,17 @@
 <resources>
     <!-- Height of the status bar in portrait. The height should be
          Max((status bar content height + waterfall top size), top cutout size) -->
-    <dimen name="status_bar_height_portrait">35.0dip</dimen>
+    <dimen name="status_bar_height_portrait">35dp</dimen>
+
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">32dp</dimen>
+
+    <!-- Radius of the software rounded corners. -->
+    <dimen name="rounded_corner_radius">144px</dimen>
+
+    <!-- Default adjustment for the software rounded corners since corners are not perfectly
+        round. This value is used when retrieving the "radius" of the rounded corner in cases
+        where the exact bezier curve cannot be retrieved.  This value will be subtracted from
+        rounded_corner_radius to more accurately provide a "radius" for the rounded corner. -->
+    <dimen name="rounded_corner_radius_adjustment">40px</dimen>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/drawable/rounded.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/drawable/rounded.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (C) 2021 The Android Open Source Project
+    You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="140px"
+        android:height="140px"
+        android:viewportWidth="140"
+        android:viewportHeight="140">
+      <path
+        android:pathData="M0,0H145.3H123.86C115.89,0.06 109.44,0.23 103.05,0.64C98.28,0.99 93.52,1.45 88.93,2.09C84.28,2.79 79.74,3.6 75.27,4.71C66.38,6.92 57.95,10 50.28,14.12C42.55,18.25 35.57,23.37 29.53,29.47C23.48,35.51 18.31,42.49 14.18,50.22C10.06,57.95 6.92,66.38 4.77,75.21C3.66,79.63 2.79,84.22 2.15,88.87C1.45,93.52 0.99,98.23 0.7,102.99C0.29,109.39 0.12,115.84 0.06,125.25V148.56Z"
+        android:fillColor="#000000" />
+</vector>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2020, The LineageOS Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Default rounded corner curve (a Bezier). Must match (the curved path in) rounded.xml.
+         Note that while rounded.xml includes the entire path (including the horizontal and vertical
+         corner edges), this pulls out just the curve.
+     -->
+    <string name="config_rounded_mask" translatable="false">M122,0 C71.76,3.59 52.03,8.07 29.6,29.6 8.07,52.03 3.59,71.76 0,122</string>
+
+    <!--  Allow CornerHandleView and PathSpecCornerPathRenderer to decouple from corner-radius -->
+    <dimen name="config_rounded_mask_size">122px</dimen>
+</resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -18,4 +18,7 @@
 <resources>
     <!-- Height of the status bar header bar when on Keyguard -->
     <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>
+
+    <!-- for 20dp of padding at 2.75px/dp at default density -->
+    <dimen name="rounded_corner_content_padding">55px</dimen>
 </resources>


### PR DESCRIPTION
This fixes the jagged corners of our display by updating the aosp rounded corner config with path drawables which are based on the ones that come with pixel 4 and pixel 4a 5G. The rounded_corner_content_padding value is also from pixel 4 since it has the same default dpi.
Based in part on this commit https://github.com/crdroidandroid/android_device_xiaomi_umi/commit/729cd90ebffd6936cbb6266f4af51ac1bf89135e